### PR TITLE
-01 changes

### DIFF
--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -1,6 +1,6 @@
 ---
-title: "Reusable templates and checksum offload for CONNECT-IP"
-abbrev: "Reusable templates and checksum offload for CONNECT-IP"
+title: "Reusable templates, derived fields, and checksum offload for HTTP Datagrams"
+abbrev: "Reusable templates, derived fields, and checksum offload for HTTP Datagrams"
 category: std
 
 docname: draft-rosomakho-masque-connect-ip-optimizations-latest
@@ -35,27 +35,33 @@ informative:
 
 --- abstract
 
-This document defines extensions to the CONNECT-IP protocol (RFC 9484) that improve the efficiency of datagram transmission by introducing reusable templates and checksum offload capabilities.
+This document defines extensions for HTTP Datagram-based protocols that improve transmission efficiency by introducing reusable templates and derived field processing contexts.
 
-Reusable templates allow endpoints to associate Context Identifiers with static portions of packet headers, enabling datagrams to omit repeated byte sequences while remaining self-contained and stateless on the wire. Checksum offload enables endpoints to delegate computation of transport-layer checksums to the receiver by signaling the relevant offsets within the reconstructed packet.
+Reusable templates allow endpoints to associate Context Identifiers with static portions of packet headers, enabling datagrams to remove repeated byte sequences while remaining stateless on the wire. Derived field processing allows receivers to reconstruct certain header fields such as packet lengths and complete checksums based on the size of the reconstructed packet.
 
-These optimisations reduce per-packet overhead, processing cost, and effectively increase the usable maximum transmission unit (MTU) when CONNECT-IP datagrams are encapsulated in QUIC DATAGRAM frames.
+Additionally, this document defines a checksum offload procedure enabling receivers to complete checksums using sender-provided partial values.
+
+These optimisations reduce per-packet overhead, processing cost, and increase the effective maximum transmission unit (MTU) when datagrams are encapsulated in QUIC DATAGRAM frames.
 
 --- middle
 
 # Introduction
 
-The CONNECT-IP method {{!CONNECT-IP=RFC9484}} allows an HTTP client to establish an IP tunnel through an HTTP proxy and exchange IP packets using either HTTP/3 Datagrams specified in {{Section 2.1 of !HTTP-DATAGRAMS=RFC9297}} or DATAGRAM capsules specified in {{Section 3.5 of HTTP-DATAGRAMS}}. Each packet is carried in full, including all transport and network headers, which provides simplicity and interoperability but incurs per-packet overhead due to the repeated transmission of largely invariant header fields.
+The CONNECT-IP method {{!CONNECT-IP=RFC9484}} allows an HTTP client to establish an IP tunnel through an HTTP proxy and exchange IP packets using either HTTP/3 Datagrams specified in {{Section 2.1 of !HTTP-DATAGRAMS=RFC9297}} or DATAGRAM capsules specified in {{Section 3.5 of HTTP-DATAGRAMS}}. Similarly, CONNECT-ETHERNET {{!CONNECT-ETHERNET=I-D.ietf-masque-connect-ethernet}} allows carriage of Ethernet frames over HTTP Datagrams. In these protocols, each packet or frame is carried in full, including all transport and network headers, which provides simplicity and interoperability but incurs per-packet overhead due to the repeated transmission of largely invariant header fields.
 
-This document introduces two optional extensions, Reusable Templates and Checksum Offload, that optimise CONNECT-IP datagram transmission without changing the existing protocol semantics.
+Other HTTP Datagram-based protocols share similar properties: datagrams often contain structured packets where many header fields remain constant across a flow while only a subset of bytes change between packets. Transmitting complete packets therefore wastes bandwidth and processing resources.
 
-Reusable templates allow endpoints to associate a Context Identifier with a reusable packet layout consisting of static and variable byte regions. Once a template has been installed using reliable Capsules, datagrams referencing the same Context Identifier carry only the variable portions of the packet. This reduces the size of transmitted datagrams and processing overhead, while maintaining on-the-wire statelessness and compatibility with intermediaries that are unaware of these optimisations.
+This document introduces a set of optional extensions that define Processing Contexts for HTTP Datagram payloads. A Processing Context describes transformations applied to a received datagram payload prior to delivery to the target protocol and may reference a parent context, forming a processing chain.
 
-Checksum offload enables endpoints to delegate computation of transport-layer checksums to the receiver by identifying the checksum field offset and the start of the checksum coverage within the reconstructed packet. This mirrors hardware checksum-offload behavior used on network interfaces and tunnel devices, reducing per-packet CPU cost for encapsulating or decapsulating CONNECT-IP traffic.
+Reusable templates allow endpoints to associate a Context Identifier with a reusable packet layout consisting of static and variable byte regions. Once a template has been installed using reliable Capsules, datagrams referencing the same Context Identifier carry only the variable portions of the packet. This reduces the size of transmitted datagrams and processing overhead, while remaining compatibile with intermediaries that are unaware of these optimisations.
 
-When CONNECT-IP datagrams are encapsulated in QUIC DATAGRAM frames, these optimisations also increase the effective maximum transmission unit (MTU) by reducing the number of bytes carried inside each QUIC packet.
+Derived field processing allows the receiver to reconstruct certain header fields (for example packet length fields and complete checksums) based on the size and structure of the reconstructed packet. This eliminates the need for the sender to transmit such fields for every packet.
 
-Both extensions are negotiated at CONNECT-IP establishment and signalled using Capsules on the reliable control stream. When necessary, endpoints can fall back to transmitting complete IP packets using Context ID 0, which represents unoptimised datagrams containing the full IP packet as defined in {{Section 5 of CONNECT-IP}}.
+In addition, this document defines a checksum offload procedure enabling endpoints to cooperatively compute Internet checksums, where the sender provides a partial checksum and the receiver completes the computation after reconstruction. This mirrors hardware checksum-offload behavior used on network interfaces and tunnel devices, reducing per-packet CPU cost for encapsulating or decapsulating CONNECT-IP and CONNECT-ETHERNET traffic.
+
+When HTTP Datagrams are encapsulated in QUIC DATAGRAM frames, these optimisations also increase the effective maximum transmission unit (MTU) by reducing the number of bytes carried inside each QUIC packet.
+
+All extensions are negotiated during the HTTP request/response handshake and signalled using Capsules on the reliable control stream. Endpoints can always fall back to transmitting complete datagrams using Context ID 0, which represents unoptimised datagrams containing the full payload as defined by the underlying HTTP Datagram protocol.
 
 # Conventions and Definitions
 
@@ -65,52 +71,81 @@ The following terms are used in this document:
 
 Context Identifier (CID):
 
-: A numeric identifier associated with a specific packet reconstruction and processing behavior. A CONNECT-IP tunnel can maintain multiple CIDs in each direction. Context ID 0 always represents transmission of complete, unoptimised IP packets as defined in {{Section 5 of CONNECT-IP}}.
+: A numeric identifier associated with a Processing Context. CID encoding and allocation follow the rules defined in {{Section 4 of !CONNECT-UDP=RFC9298}}. CID 0 indicates that the datagram payload is delivered without additional processing as defined by the underlying HTTP Datagram protocol.
+
+Processing Context:
+
+: A set of rules describing how an HTTP Datagram payload is transformed before delivery to the target protocol. A Processing Context may reference a parent context, forming a processing chain. Processing Contexts are immutable once created.
 
 Template:
 
-: A reusable packet layout consisting of a sequence of static and variable segments. Static segments contain bytes omitted from optimized datagrams, while variable segments correspond to bytes still carried in the datagram payload.
+: A reusable packet layout consisting of a sequence of static and variable segments. Static segments contain bytes removed from optimized datagrams, while variable segments correspond to bytes still carried in the datagram payload.
+
+Derived Field:
+
+: A header field whose value is generated by the receiver during reconstruction and written into the reconstructed packet rather than being transmitted in the datagram payload. Derived fields include length fields and complete checksums.
 
 Checksum Offload:
 
-: A capability allowing the receiver to compute and finalize the Internet checksum according to {{!INCREMENTAL-CHECKSUM=RFC1624}} for the reconstructed packet, based on two offsets: `Checksum Field Offset` and `Checksum Start Offset`.
+: A capability allowing the receiver to complete the Internet checksum according to {{!INCREMENTAL-CHECKSUM=RFC1624}} using a sender-provided partial checksum after reconstruction of the packet.
 
 Capsule:
 
-: A reliable control-stream message, as defined in {{Section 3 of HTTP-DATAGRAMS}}, used in this specification to signal creation or deletion of Context Identifiers and their associated templates.
+: A reliable control-stream message, as defined in {{Section 3 of HTTP-DATAGRAMS}}, used in this specification to signal creation, acknowledgement, or deletion of Processing Contexts.
 
 # Negotiation of Capabilities {#negotiation}
 
-Endpoints negotiate support for these optimizations when establishing a CONNECT-IP tunnel by using a `connect-ip-optimizations` HTTP header field, whose value is a Structured Field Dictionary as defined in {{Section 3.2 of !STRUCTURED-HTTP=RFC8941}}.
+Endpoints negotiate support for HTTP Datagram processing contexts during the HTTP request/response handshake by using the `http-datagram-contexts` HTTP header field, whose value is a Structured Field Dictionary as defined in {{Section 3.2 of !STRUCTURED-HTTP=RFC8941}}.
 
 ## Header Definition
 
 ~~~
-connect-ip-optimizations = sf-dictionary
+http-datagram-contexts = sf-dictionary
 ~~~
-{: #fig-connect-ip-optimizations-header title="Connect-ip-optimizations header field"}
+{: #fig-http-datagram-contexts-header title="http-datagram-contexts header field"}
 
 This document defines the following optional dictionary keys:
 
-`templates` (sf-interger):
+`templates` (sf-dictionary):
 
-: Indicates support for reusable templates and specifies the maximum number of templates that the sender is willing to maintain for templates received from the peer. A positive integer value indicates full support for reusable templates, and the value represents an upper bound on the number of concurrently active templates that can be created by the peer. A value of 0 indicates that the sender supports reusable templates only for its own transmissions but does not accept templates created by the peer. If this member is omitted, reusable templates are not supported in either direction.
+: Indicates support for reusable templates. The dictionary contains:
+
+* `max` (sf-integer, mandatory): maximum number of concurrently active template contexts the sender is willing to maintain for templates created by the peer. A value of 0 indicates that the endpoint does not accept templates from the peer but may use templates for its own transmissions.
+* `segments` (sf-integer, optional): maximum number of static segments accepted within a single template.
+
+`derived` (sf-list):
+
+: A list of supported Derived Field Types as defined in {{iana-derived-fields}}.
 
 `checksum` (sf-boolean):
 
-: Indicates support for checksum offload semantics. A value of `?1` means that checksum offload is supported in both directions. A value of `?0` means that checksum offload may be used for packets sent by this endpoint but not for packets received from the peer. If this member is omitted, checksum offload is not supported in either direction.
+: Indicates support for the checksum offload procedure defined in this document. A value of ?1 means the endpoint is willing to complete checksums using sender-provided partial values. If omitted or set to ?0, checksum offload is not supported.
 
-Endpoints MUST ignore unknown dictionary members. The absence of a member implies that the corresponding capability is not supported by the sender.
+`mtu` (sf-integer):
+
+: Upper limit on maximum reconstructed packet size the receiver is willing to accept.
+
+Endpoints MUST ignore unknown dictionary members. The absence of a member implies that the corresponding capability is not supported for contexts created by the peer.
 
 ## Negotiation Behavior
 
-If both peers indicate support for templates (that is, `templates` member is present and non-zero in both directions), either endpoint MAY create and delete Context Identifiers and their templates using capsules as described in {{capsules}}.
+Capabilities are directional. Each endpoint advertises the processing contexts it is willing to receive and maintain for datagrams sent by the peer. An endpoint MAY create a context only if the peer advertised support for the corresponding capability.
 
-If both peers indicate support for checksum offload (that is, `checksum=?1` in both directions), either endpoint MAY install checksum offload parameters for specific Context Identifiers using capsules as described in {{optimization-create}}.
+### Templates
 
-Peers of endpoints that advertise support in only one direction (for example, `checksum=?0` or `templates=0`) MUST NOT send capsules that would require those endpoints to maintain state for the corresponding capability.
+If the peer advertises the `templates` member with a `max` value greater than 0, the endpoint MAY create template contexts up to that limit using capsules defined in {{capsules}}.
 
-Capabilities that were not successfully negotiated MUST NOT be used within the tunnel.
+An endpoint MUST NOT create templates exceeding the peer's advertised `segments` limit when that parameter is present.
+
+If the peer advertises an `mtu` limit, the sender MUST NOT transmit a datagram that would reconstruct into a packet larger than the advertised limit after all processing contexts have been applied.
+
+### Derived Fields
+
+An endpoint MAY create a derived context only if every operation in the capsule appears in the peer's `derived` list.
+
+### Checksum Offload
+
+An endpoint MAY create a checksum offload context only if the peer advertised `checksum=?1`.
 
 ## Example
 
@@ -123,77 +158,67 @@ HTTP/3 sample request (client to proxy):
 :path = /.well-known/masque/ip/*/*/
 :authority = proxy.example.net
 capsule-protocol = ?1
-connect-ip-optimizations = templates=20000, checksum=?1
+http-datagram-contexts = templates=(max=20000 segments=32), derived=(0 2 4), checksum=?1, mtu=1500
 ~~~
-{: #fig-connect-ip-optimizations-request-example title="CONNECT-IP with connect-ip-optimizations request example"}
+{: #fig-connect-ip-http-datagram-contexts-request-example title="CONNECT-IP with http-datagram-contexts request example"}
 
 HTTP/3 sample response (proxy to client):
 
 ~~~
 :status = 200
 capsule-protocol = ?1
-connect-ip-optimizations = templates=65535, checksum=?0
+http-datagram-contexts = templates=(max=65535), derived=(0 1), checksum=?0, mtu=1500
 ~~~
-{: #fig-connect-ip-optimizations-response-example title="CONNECT-IP with connect-ip-optimizations response example"}
+{: #fig-connect-ip-http-datagram-contexts-response-example title="CONNECT-IP with http-datagram-contexts response example"}
 
-In this example, both peers support reusable templates, and checksum offload is supported only for packets sent from the proxy to the client.
+In this example, both peers support reusable templates. The proxy supports a subset of derived fields (ipv4-total-length, ipv4-udp-length and ipv4-header-checksum) and the checksum offload. The client supports a different subset of derived fields (ipv4-total-length and ipv6-payload-length) without the checksum offload. Both endpoints indicate that the maximum packet size after reconstruction must not exceed 1500 bytes.
 
-After this exchange, both endpoints may define Context Identifiers and associated templates and/or checksum parameters using capsules on the reliable control stream.
+# Processing Context Capsules {#capsules}
 
-# Optimization capsules {#capsules}
+This specification defines multiple capsule types to construct, acknowledge, and delete processing contexts.
 
-This specification defines two capsule types:
+## Processing Context Overview
 
-CONNECT_IP_OPTIMIZATION_CREATE (capsule type 0x1a768469):
+### Processing Context Construction {#assign}
 
-: Creates an immutable optimization context bound to a Context ID.
+Processing contexts are created using capsules that define a new unique non-zero `Context ID` encoded as a variable-length integer. A CID MUST NOT be reused. As specified in {{Section 4 of CONNECT-UDP}}, even-numbered CIDs are allocated by the client and odd-numbered by the proxy.
 
-CONNECT_IP_OPTIMIZATION_DELETE (capsule type 0x1a76846a):
+Each processing context MAY reference an already-defined parent context using `Next Context ID` encoded as a variable-length integer. A context MUST reference only a CID previously defined by the peer. Forward references are not permitted. Processing context without a parent is identified by `Next Context ID` set to 0. A processing chain MUST NOT contain more than one context of the same type. A receiver that detects such a condition MUST treat the context as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
-: Retires a CID.
+A receiver of an *_ASSIGN capsule with an invalid `Context ID` or unknown `Next Context ID` MUST treat it as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
-All capsules are sent on the reliable control stream of the CONNECT-IP tunnel.
+### Processing Context Acknowledgement {#ack}
 
-## Context ID allocation
+For each *_ASSIGN capsule received, the receiver MUST transmit the corresponding *_ACK capsule after successfully installing the context.
 
-The Context ID carried in these capsules is encoded as a QUIC variable-length integer defined in {{Section 16 of ?QUIC=RFC9000}}. Even-numbered CIDs are allocated by the client, and odd-numbered CIDs are allocated by the proxy, consistent with {{Section 4 of !CONNECT-UDP=RFC9298}}. CID 0 is reserved for unoptimized raw packets and MUST NOT appear in these capsules.
+Endpoints MAY transmit datagrams referencing contexts prior to receiving the *_ACK. A receiver MAY buffer datagrams referencing unknown Context IDs but MUST bound buffering by time and memory.
 
-## CONNECT_IP_OPTIMIZATION_CREATE capsule {#optimization-create}
+A receiver of an *_ACK capsule with an unknown Context ID or any data after Context ID MUST treat it as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
-CONNECT_IP_OPTIMIZATION_CREATE capsule is used to create a new, immutable optimization context for the indicated CID.
+### Processing Context Closure {#close}
+
+Processing Contexts are retired by sending corresponding *_CLOSE capsule. Closing a context implicitly closes all contexts that reference it directly or transitively.
+
+A receiver of a *_CLOSE capsule SHOULD retain the closed context and its descendants for a short period to allow in-flight datagrams to arrive, but MUST bound the retention time and memory usage.
+
+*_CLOSE capsules with unknown Context ID or any data after Context ID MUST be treated as malformed. Receiver of such capsules MUST follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
+
+## Template Capsules
+
+### TEMPLATE_ASSIGN Capsule {#template-assign}
 
 ~~~
-CONNECT_IP_OPTIMIZATION_CREATE Capsule {
-  Type (i) = 0x1a768469,
+TEMPLATE_ASSIGN Capsule {
+  Type (i) = 0x3ee3143f,
   Length (i),
   Context ID (i),
-  Static Segments Length (i),
-  Static Segment (..) ...,
-  Checksum Field Offset (i)?,
-  Checksum Start Offset (i)?,
+  Next Context ID (i),
+  Static Segment (..) ...
 }
 ~~~
-{: #fig-optimization-create-capsule title="CONNECT_IP_OPTIMIZATION_CREATE Capsule Format"}
+{: #fig-template-assign-capsule title="TEMPLATE_ASSIGN Capsule Format"}
 
-CONNECT_IP_OPTIMIZATION_CREATE capsule contains the following fields:
-
-Context ID:
-
-: Context Identifier, encoded as a variable-length integer, defined by this capsule.
-
-Static Segments Length:
-
-: Aggregate length in bytes of all subsequent Static Segments. A value of 0 indicates that no template is used (that is, the payload of datagrams for the given Context ID contains a full reconstructed packet, modulo checksum finishing if configured).
-
-Checksum Field Offset:
-
-: An optional field, encoded as a variable-length integer, containing byte offset of the 16-bit Internet checksum field within the reconstructed packet. This field is omitted if checksum offload is not used.
-
-Checksum Start Offset:
-
-: An optional field, encoded as a variable-length integer, containing byte offset where checksum coverage begins. Coverage runs from this offset to the end of the reconstructed packet. Not included in the capsule if checksum offloading is not used.
-
-The CONNECT_IP_OPTIMIZATION_CREATE capsule contains a sequence of zero or more Static Segments.
+The TEMPLATE_ASSIGN capsule contains a sequence of one or more Static Segments.
 
 ~~~
 Static Segment {
@@ -218,66 +243,253 @@ Segment Payload:
 
 : the static bytes to insert at the Segment Offset
 
-### Parsing and validation
+#### Parsing and validation
 
-The receiver parses an CONNECT_IP_OPTIMIZATION_CREATE capsule by reading, in order: the Context ID, the Static Segments Length, zero or more static segments whose encodings consume exactly Static Segments Length bytes, and then two checksum offsets if they are present.
+The receiver parses a TEMPLATE_ASSIGN capsule by reading, in order: the Context ID, the Next Context ID, and one or more static segments whose encodings consume exactly the remaining length of the capsule. Context ID and Next Context ID processing is described in {{assign}}.
 
-The Context ID MUST be non-zero, even-numbered when created by the client, and odd-numbered when created by the proxy. The Context ID MUST NOT have been used previously. Static Segments Length is the total size, in bytes, of the static segments section including each Segmenet Offset, Segment Length, and Segment Payload.
+Each Static Segment consists of a Segment Offset, a Segment Length, and exactly Segment Length octets of Segment Payload. Static segments MUST appear in strictly increasing Segment Offset order and MUST NOT overlap. There MUST be at least 1 byte between consecutive segments.
 
-Each Static Segment consists of a Segment Offset, a Segment Length, and exactly Segment Length octets of Segment Payload. Static segments MUST appear in strictly increasing Segment Offset order and MUST NOT overlap.
-
-After Static Segments Length bytes have been consumed, the capsule either ends immediately or contains exactly two additional fields: Checksum Field Offset followed by Checksum Start Offset. If only one variable-length integer is present, or if any bytes remain after the two length integers, the capsule is malformed.
-
-A receiver that did not negotiate acceptance of checksum offload in its direction as defined in {{negotiation}} MUST treat an CONNECT_IP_OPTIMIZATION_CREATE capsule that includes checksum offsets as an error and MUST follow the error-handling procedure in {{Section 3.3 of HTTP-DATAGRAMS}}. A receiver that has already accepted the maximum number of templates it advertised via the templates member of `connect-ip-optimizations` MUST treat any additional CONNECT_IP_OPTIMIZATION_CREATE capsule containing a template (that is, with Static Segments Length > 0) as an error and MUST follow the same error-handling procedure.
+A receiver that advertised a `segments` limit in `templates` dictionary of `http-datagram-contexts` MUST ensure that the template does not contain more static segments. A receiver that advertised a `mtu` limit in `http-datagram-contexts` MUST ensure that the sum of Segment Offset and Segment Length of the final segment does not exceed the MTU limit. Final reconstructed packet size validation is performed during packet reconstruction ({{reconstruction}}). The capsule MUST end immediately after the last static segment.
 
 If any of the capsule fields are malformed upon reception, the receiver of the capsule MUST follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
+A receiver that has already accepted the maximum number of templates it advertised via the `max` member of `templates` in `http-datagram-contexts` MUST treat any additional TEMPLATE_ASSIGN capsule an error and MUST follow the same error-handling procedure.
+
 Per-packet validation uses the reconstruction procedure described in {{reconstruction}}.
 
-## CONNECT_IP_OPTIMIZATION_DELETE capsule
-
-CONNECT_IP_OPTIMIZATION_DELETE capsule is used to indicate that a Context ID previously defined by CONNECT_IP_OPTIMIZATION_CREATE capsule will no longer be used.
+### TEMPLATE_ACK Capsule
 
 ~~~
-CONNECT_IP_OPTIMIZATION_DELETE Capsule {
-  Type (i) = 0x1a76846a,
+TEMPLATE_ACK Capsule {
+  Type (i) = 0x3ee31440,
   Length (i),
   Context ID (i),
 }
 ~~~
-{: #fig-optimization-delete-capsule title="CONNECT_IP_OPTIMIZATION_DELETE Capsule Format"}
+{: #fig-template-ack-capsule title="TEMPLATE_ACK Capsule Format"}
 
-After sending an CONNECT_IP_OPTIMIZATION_DELETE Capsule, the sender MUST NOT use the Context ID. Upon receipt, the peer retires the indicated context and releases any negotiated template budget consumed by that context if, and only if, the retired context included a template (that is, its CONNECT_IP_OPTIMIZATION_CREATE had a non-zero Static Segments Length). Retiring a context that had no template (for example, checksum-only) does not affect the template budget.
+Processing of the TEMPLATE_ACK capsule is described in {{ack}}
 
-If an CONNECT_IP_OPTIMIZATION_DELETE capsule is received for a Context ID that was not previously and correctly defined by an CONNECT_IP_OPTIMIZATION_CREATE capsule from the peer, the receiver MUST follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
+### TEMPLATE_CLOSE Capsule
 
-# Optimized Datagram Operation
+~~~
+TEMPLATE_CLOSE Capsule {
+  Type (i) = 0x3ee31441,
+  Length (i),
+  Context ID (i),
+}
+~~~
+{: #fig-template-close-capsule title="TEMPLATE_CLOSE Capsule Format"}
 
-This section defines how endpoints construct and consume datagrams once a Context ID has been created with CONNECT_IP_OPTIMIZATION_CREATE capsule.
+Processing of the TEMPLATE_CLOSE capsule is described in {{close}}
+
+## Derived Field Capsules
+
+### DERIVED_ASSIGN Capsule
+
+~~~
+DERIVED_ASSIGN Capsule {
+  Type (i) = 0x3ee31442,
+  Length (i),
+  Context ID (i),
+  Next Context ID (i),
+  Derived Field Type (i) ...
+}
+~~~
+{: #fig-derived-assign-capsule title="DERIVED_ASSIGN Capsule Format"}
+
+The DERIVED_ASSIGN capsule defines a processing context that generates and inserts one or more derived fields into the reconstructed packet. The sender does not transmit these fields in the datagram payload.
+
+#### Parsing and validation
+
+The receiver parses a DERIVED_ASSIGN capsule by reading, in order: the Context ID, the Next Context ID, and one or more Derived Field Type values encoded as variable-length integers. Context ID and Next Context ID processing is described in {{assign}}.
+
+If a Derived Field Type is not present in the receiver's advertised `derived` capability list in `http-datagram-contexts` or if any Derived Field Type appears more than once in the capsule, the receiver MUST treat the capsule as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
+
+Per-packet validation uses the reconstruction procedure described in {{reconstruction}}.
+
+### DERIVED_ACK Capsule
+
+~~~
+DERIVED_ACK Capsule {
+  Type (i) = 0x3ee31443,
+  Length (i),
+  Context ID (i),
+}
+~~~
+{: #fig-derived-ack-capsule title="DERIVED_ACK Capsule Format"}
+
+Processing of the DERIVED_ACK capsule is described in {{ack}}
+
+### DERIVED_CLOSE Capsule
+
+~~~
+DERIVED_CLOSE Capsule {
+  Type (i) = 0x3ee31444,
+  Length (i),
+  Context ID (i),
+}
+~~~
+{: #fig-derived-close-capsule title="DERIVED_CLOSE Capsule Format"}
+
+Processing of the DERIVED_CLOSE capsule is described in {{close}}
+
+## Checksum Offload Capsules
+
+### CHECKSUM_ASSIGN Capsule
+
+~~~
+CHECKSUM_ASSIGN Capsule {
+  Type (i) = 0x3ee31445,
+  Length (i),
+  Context ID (i),
+  Next Context ID (i),
+  Checksum Field Offset (i),
+  Checksum Start Offset (i),
+}
+~~~
+{: #fig-checksum-assign-capsule title="CHECKSUM_ASSIGN Capsule Format"}
+
+The CHECKSUM_ASSIGN capsule defines a processing context that completes an Internet checksum for the reconstructed packet using a sender-provided partial checksum.
+
+In addition to `Context ID` and `Next Context ID` CHECKSUM_ASSIGN capsule contains following fields encoded as variable-length integers:
+
+`Checksum Field Offset`:
+
+: Byte offset of the 16-bit Internet checksum field within the reconstructed packet
+
+`Checksum Start Offset`:
+
+: Byte offset where checksum coverage begins.  Coverage runs from this offset to the end of the reconstructed packet.
+
+#### Parsing and validation
+
+The receiver parses a CHECKSUM_ASSIGN capsule by reading, in order: the Context ID, the Next Context ID, Checksum Field Offset and Checksum Start Offset. Context ID and Next Context ID processing is described in {{assign}}.
+
+If the peer did not advertise `checksum=?1` in `http-datagram-contexts`, the receiver MUST treat the capsule as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
+
+If `Checksum Start Offset` is 0, the receiver MUST treat the capsule as malformed and follow the same error-handling procedure.
+
+Per-packet validation uses the reconstruction procedure described in {{reconstruction}}.
+
+### CHECKSUM_ACK Capsule
+
+~~~
+CHECKSUM_ACK Capsule {
+  Type (i) = 0x3ee31446,
+  Length (i),
+  Context ID (i),
+}
+~~~
+{: #fig-checksum-ack-capsule title="CHECKSUM_ACK Capsule Format"}
+
+Processing of the CHECKSUM_ACK capsule is described in {{ack}}
+
+### CHECKSUM_CLOSE Capsule
+
+~~~
+CHECKSUM_CLOSE Capsule {
+  Type (i) = 0x3ee31447,
+  Length (i),
+  Context ID (i),
+}
+~~~
+{: #fig-checksum-close-capsule title="CHECKSUM_CLOSE Capsule Format"}
+
+Processing of the CHECKSUM_CLOSE capsule is described in {{close}}
+
+# Processing Context Operation
+
+This section defines how endpoints construct and consume HTTP Datagram payloads using Processing Contexts.
+
+A datagram carries a Context Identifier that selects the initial Processing Context. A context MAY reference a parent context using Next Context ID. The complete behavior is defined by recursively following parent contexts until reaching CID 0.
+
+CID 0 indicates that no processing is applied and the payload is delivered unchanged to the underlying HTTP Datagram protocol.
 
 ## Sender behavior
 
-For each packet sent under a Context ID, the sender constructs the datagram payload according to the context's template. If the context has no template (that is, Static Segments Length is 0), the payload MUST be a complete reconstructed packet. If the context has a template, the payload MUST be the concatenation of all variable byte ranges, taken in strictly increasing offset order, corresponding to the gaps not covered by static segments starting at offset 0.
+When sending a datagram using a Processing Context, the sender constructs the payload so that the receiver can reconstruct the final packet after applying the processing chain.
 
-When checksum offload is configured (that is, the context includes Checksum Field Offset and Checksum Start Offset), the sender MUST set the checksum field in the reconstructed packet image to the 16-bit one’s-complement sum of the appropriate pseudo-header before transmission. The two bytes at Checksum Field Offset in the reconstructed image therefore MUST contain this pseudo-header sum; these bytes originates from static bytes in the template as well as from variable bytes in the payload. The final reconstructed image MUST contain the correct preseeding value.
+The sender MUST use a Context ID only after the corresponding *_ASSIGN capsule has been transmitted.
 
-A sender uses Context ID 0 for any one-off packet that does not fit an existing context (for example, a transient change in header layout).
+### Template Contexts
+
+If the selected context chain contains a Template context, the sender constructs the datagram payload as the concatenation of all variable byte regions not covered by static segments.
+
+Variable regions are emitted in strictly increasing offset order starting at offset 0.
+
+If the context chain contains no Template context, the payload MUST be the complete packet.
+
+### Derived Field Contexts
+
+Derived fields are not transmitted by the sender. When a derived context is in use, the sender MUST remove the octets corresponding to derived fields from the datagram payload. These octets are supplied by the receiver during reconstruction.
+
+The sender MUST construct the payload as if the derived field octets were not part of the variable regions. That is, the payload MUST contain only the remaining variable octets in strictly increasing offset order.
+
+### Checksum Offload Contexts
+
+If the context chain contains a checksum offload context, the sender MUST place a precomputed partial Internet checksum value into the checksum field at Checksum Field Offset in the reconstructed packet image prior to transmission. This value is combined with the receiver computation as described in {{reconstruction}}.
+
+### Context Selection
+
+If a packet does not match any available context, the sender MUST use CID 0 and transmit the complete packet.
 
 ## Receiver behavior {#reconstruction}
 
-A datagram that arrives with a non-zero Context ID that has not been previously and correctly defined by an CONNECT_IP_OPTIMIZATION_CREATE capsule from the peer MUST be dropped.
+Upon receiving an HTTP Datagram with a non-zero Context ID, the receiver retrieves the referenced Processing Context and recursively resolves its parent contexts until CID 0 is reached.
 
-If the CID has no template (that is, Static Segments Length is 0), the datagram payload is the complete reconstructed packet. If the CID has a template, the receiver reconstructs the packet from offset 0 upward by writing static bytes at their declared offsets and filling all remaining byte positions with bytes consumed from the datagram payload in strictly increasing offset order. Reconstruction continues until all payload bytes have been consumed. If the payload is exhausted before the offset of the last static segment have been filled, the packet MUST be dropped.
+If any referenced context is unknown, the receiver MAY buffer the datagram as described in {{ack}} or drop it.
 
-When Checksum Field Offset and Checksum Start Offset are present for the CID, the receiver finishes the Internet checksum as follows: it computes the checksum over the byte range starting at Checksum Start Offset and ending at the reconstructed packet length while treating the checksum field as zero during the sum; it then adds (folds) the 16-bit value currently at Checksum Field Offset, performs end-around carry, and writes the final one's-complement result back at Checksum Field Offset. If either checksum offset is greater than or equal to the reconstructed packet length for this packet, the packet MUST be dropped.
+If multiple processing contexts are present in a chain, the receiver MUST apply them in the following order:
+
+1. Template reconstruction (if present)
+1. Derived field processing (if present)
+1. Checksum offload processing (if present)
+
+### Template Reconstruction
+
+If a Template context is present, the receiver reconstructs the packet as follows:
+
+1. Allocate a buffer large enough to contain the reconstructed packet.
+1. Insert static segment bytes at their specified offsets.
+1. Fill all remaining gaps using bytes from the datagram payload in strictly increasing offset order.
+
+If payload bytes are exhausted before all gaps have been filled the datagram MUST be dropped.
+
+Packets larger than the advertised `mtu` in `http-datagram-contexts` MUST be dropped.
+
+### Derived Field Processing
+
+For each derived field present in the context chain, the receiver computes the field value and inserts it into the reconstructed packet at the location defined by the derived field type.
+
+Derived fields are inserted into the packet image and therefore increase the reconstructed packet size. The receiver MUST compute derived field values based on the final reconstructed packet size and structure.
+
+Initial field definitions are specified in {{iana-derived-fields}}.
+
+If the required header cannot be located, the packet MUST be dropped.
+
+### Checksum Offload Processing
+
+If a checksum offload context is present, the receiver completes the Internet checksum after all derived fields have been inserted.
+
+The receiver completes the checksum as follows:
+
+1. Treat the checksum field as zero.
+1. Compute the one's-complement sum from Checksum Start Offset to L.
+1. Add (fold) the 16-bit value currently present at the checksum field.
+1. Write the final one's-complement result to the checksum field.
+
+If any offset exceeds the reconstructed packet length, the packet MUST be dropped.
 
 # Examples
 
 This section illustrates how contexts are created and how senders form compact payloads. All offsets and lengths are in bits in the packet diagrams and field tables. All offsets and lengths are in bytes in segment tables and sample capsules.
 
-## TCP over IPv6 with template and checksum offload
+## CONNECT-IP: TCP over IPv6 with template, derived fields and checksum offload
 
 Original sample {{?TCP=RFC9293}} over {{?IPv6=RFC8200}} packet layout is illustrated below. In addition to basic IPv6 and TCP headers it contains Timestamp option as defined in {{Section 3 of ?TCP-PERF=RFC7323}}.
+
+This packet is to be transmitted from the client to the proxy over CONNECT-IP.
 
 ~~~ aasvg
 |0              7|8             15|16            23|16            31|
@@ -325,33 +537,66 @@ Original sample {{?TCP=RFC9293}} over {{?IPv6=RFC8200}} packet layout is illustr
 ~~~
 {: #original-tcp-ipv6 title="Example TCP over IPv6 packet before optimization"}
 
-Table below illustrates fields present in IPv6 and TCP headers, their offsets in bits from the beginning of the packet and whether they are likely to be static for most packets of a given traffic flow
+This example assumes that the peer supports templates with at least two segments per template, IPv6 payload length derived field and checksum offloading. These capabilities were communicated using the following `http-datagram-contexts` HTTP field in proxy response confirming CONNECT-IP extended CONNECT.
+
+~~~
+http-datagram-contexts = templates=(max=1 segments=2), derived=(1), checksum=?1, mtu=1500
+~~~
+{: #fig-http-datagram-contexts-example-1 title="http-datagram-contexts response example"}
+
+Since the proxy does not support TCP checksum derivation, but it supports checksum offloading, the client calculates checksum of IPv6 pseudo-header and places it in the TCP checksum field. Context for the offloaded checksum is defined using the CHECKSUM_ASSIGN capsule:
+
+~~~
+CHECKSUM_ASSIGN Capsule {
+  Type (i) = 0x3ee31445,
+  Length (i) = 4,
+  Context ID (i) = 2,
+  Next Context ID (i) = 0,
+  Checksum Field Offset (i) = 56,
+  Checksum Start Offset (i) = 40,
+}
+~~~
+{: #ipv6-tcp-checksum-assign title="CHECKSUM_ASSIGN Capsule for example IPv6/TCP packet"}
+
+Payload length field in IPv6 header can derived by the peer, so it is removed before calculating static segments. Resulting context for the derived field is defined using DERIVED_ASSIGN capsule:
+
+~~~
+DERIVED_ASSIGN Capsule {
+  Type (i) = 0x3ee31442,
+  Length (i) = 3,
+  Context ID (i) = 4,
+  Next Context ID (i) = 2,
+  Derived Field Type (i) = 1
+}
+~~~
+{: #ipv6-tcp-derived-assign title="DERIVED_ASSIGN Capsule for example IPv6/TCP packet"}
+
+Table below illustrates fields present in IPv6 and TCP headers after derived field was removed, their offsets in bits from the beginning of the packet and whether they are likely to be static for most packets of a given traffic flow
 
 | Offset | Field name | Length | Value | Static |
 | --- | --- | --- | --- | --- |
 | 0 | Version | 4 | 0110b | Yes |
 | 4 | Traffic Class | 8 | 0x00 | Yes |
 | 12 | Flow label | 20 | 0x4bcde | Yes |
-| 32 | Payload length | 16 | 0x0020 | No |
-| 48 | Next header | 8 | 0x06 | Yes |
-| 56 | Hop limit | 8 | 0x79 | Yes |
-| 64 | Source address | 128 | 2001:0db8:85a3::8a2e:0370:7334 | Yes |
-| 192 | Destination address | 128 | 2001:0db8:a42b::7c3a:143a:1529 | Yes |
-| 320 | Source port | 16 | 0x0050 | Yes |
-| 336 | Destination port | 16 | 0xd475 | Yes |
-| 352 | Sequence number | 32 | 0x6caa4bd7 | No |
-| 384 | Acknowledgement number | 32 | 0x9b16794e | No |
-| 416 | TCP header length | 4 | 1000b | Yes |
-| 420 | TCP Flags | 12 | 000000010000b | No |
-| 432 | Window | 16 | 0x041e | No |
-| 448 | Checksum | 16 | 0x8f6b | No |
-| 464 | Urgent pointer | 16 | 0x0000 | Yes |
-| 480 | No-Op option | 8 | 0x01 | Yes |
-| 488 | No-Op option | 8 | 0x01 | Yes |
-| 496 | Timestamp option | 8 | 0x08 | Yes |
-| 504 | Timestamp option length | 8 | 0x0a | Yes |
-| 512 | Timestamp value | 32 | 0x119a5db3 | No |
-| 544 | Timestamp echo reply | 32 | 0xd9b4d48d | No |
+| 32 | Next header | 8 | 0x06 | Yes |
+| 40 | Hop limit | 8 | 0x79 | Yes |
+| 48 | Source address | 128 | 2001:0db8:85a3::8a2e:0370:7334 | Yes |
+| 176 | Destination address | 128 | 2001:0db8:a42b::7c3a:143a:1529 | Yes |
+| 304 | Source port | 16 | 0x0050 | Yes |
+| 320 | Destination port | 16 | 0xd475 | Yes |
+| 336 | Sequence number | 32 | 0x6caa4bd7 | No |
+| 368 | Acknowledgement number | 32 | 0x9b16794e | No |
+| 400 | TCP header length | 4 | 1000b | Yes |
+| 404 | TCP Flags | 12 | 000000010000b | No |
+| 416 | Window | 16 | 0x041e | No |
+| 432 | Checksum | 16 | 0x8f6b | No |
+| 448 | Urgent pointer | 16 | 0x0000 | Yes |
+| 464 | No-Op option | 8 | 0x01 | Yes |
+| 472 | No-Op option | 8 | 0x01 | Yes |
+| 480 | Timestamp option | 8 | 0x08 | Yes |
+| 488 | Timestamp option length | 8 | 0x0a | Yes |
+| 496 | Timestamp value | 32 | 0x119a5db3 | No |
+| 528 | Timestamp echo reply | 32 | 0xd9b4d48d | No |
 {: #ipv6-tcp-fields title="IPv6 and TCP header fields in example packet"}
 
 Static segments model the invariant parts except for the isolated 4-bit TCP header length.
@@ -360,49 +605,57 @@ Resulting static segments:
 
 | Segment Offset | Segment Length | Segment Contents | Segment Payload |
 | --- | --- | --- | --- |
-| 0 | 4 | Version, Traffic Class and Flow Label | 0x6004bcde |
-| 6 | 38 | Next header, Hop limit, Source address, Destination address, Source port, Destination port | 0x067920010db885a3... |
-| 58 | 6 | Urgent pointer, 2 No-Op TCP options, Timestamp option code and length | 0x00000101080a |
+| 0 | 42 | Version, Traffic Class, Flow Label, Next header, Hop limit, Source address, Destination address, Source port, Destination port | 0x6004bcde067920010db885a3... |
+| 56 | 6 | Urgent pointer, 2 No-Op TCP options, Timestamp option code and length | 0x00000101080a |
 {: #ipv6-tcp-segments title="Static segments for example IPv6/TCP packet"}
 
-Resulting CONNECT_IP_OPTIMIZATION_CREATE capsule with client-allocated even context id is illustrated below:
+Resulting TEMPLATE_ASSIGN capsule with client-allocated even context id is illustrated below:
 
 ~~~
-CONNECT_IP_OPTIMIZATION_CREATE Capsule {
-  Type (i) = 0x1a768469,
-  Length (i) = 58,
-  Context ID (i) = 2,
-  Static Segments Length (i) = 54,
+TEMPLATE_ASSIGN Capsule {
+  Type (i) = 0x3ee3143f,
+  Length (i) = 54,
+  Context ID (i) = 6,
+  Next Context ID (i) = 4,
   Static Segment {
     Segment Offset (i) = 0,
-    Segment Length (i) = 4,
-    Segment Payload = 0x6004bcde,
+    Segment Length (i) = 42,
+    Segment Payload = 0x6004bcde067920010db885a3000000008a2e0370733420010db8a42b000000007c3a143a15290050d475,
   },
   Static Segment {
-    Segment Offset (i) = 6,
-    Segment Length (i) = 38,
-    Segment Payload = 0x067920010db885a3000000008a2e0370733420010db8a42b000000007c3a143a15290050d475,
-  },
-  Static Segment {
-    Segment Offset (i) = 58,
+    Segment Offset (i) = 56,
     Segment Length (i) = 6,
     Segment Payload = 0x00000101080a,
-  },
-  Checksum Field Offset (i) = 56,
-  Checksum Start Offset (i) = 40,
+  }
 }
 ~~~
-{: #ipv6-tcp-optimization-create title="CONNECT_IP_OPTIMIZATION_CREATE Capsule for example IPv6/TCP packet"}
+{: #ipv6-tcp-template-assign title="TEMPLATE_ASSIGN Capsule for example IPv6/TCP packet"}
 
-This template reduces per-packet overhead by omitting 48 bytes of repeated header material, increasing the effective MTU when datagrams are encapsulated in QUIC DATAGRAM frames.
+The resulting processing context chain reduces per-packet overhead by removing 50 bytes of repeated header material, increasing the effective MTU when datagrams are encapsulated in QUIC DATAGRAM frames.
 
-The sender concatenates all variable regions in increasing offset order and replaces checksum field with the IPv6/TCP pseudo-header checksum. Packets that do not match this template (for example packets with IPv6 extension headers or without TCP options) are sent using Context ID 0 or associated with a new context.
+The sender concatenates all variable regions in increasing offset order. Packets that do not match this template (for example packets with IPv6 extension headers or without TCP options) are sent using Context ID 0 or associated with a new context.
 
-## UDP over IPv4 with template and without checksum offload
+Upon receiving the datagram with CID 6, proxy re-assembles the datagram by concatenating static and variable segments according to the offsets, re-calculates Payload Length and inserts it into IPv6 header and completes the TCP checksum using the sender-provided pseudo-header partial checksum.
 
-Original sample {{?UDP=RFC768}} over {{?IPv4=RFC791}} packet layout is illustrated below.
+## CONNECT-ETHERNET: UDP over IPv4 with template and derived fields
+
+Original sample {{?UDP=RFC768}} over {{?IPv4=RFC791}} Ethernet frame layout is illustrated below.
+
+This frame is to be transmitted from the proxy to the client over CONNECT-ETHERNET.
 
 ~~~ aasvg
+|0      7|8     15|16    23|24    31|32    39|40    47|
++--------+--------+--------+--------+--------+--------+
+|               Destination MAC address               |
+|                  00:00:5E:00:53:01                  |
++--------+--------+--------+--------+--------+--------+
+|                 Source MAC address                  |
+|                  00:00:5E:00:53:02                  |
++--------+--------+--------+--------+--------+--------+
+|     0x0800      |
+|    EtherType    |            ETHERNET HEADER
++-----------------+
+
 |0              7|8             15|16            23|16            31|
 +--------+-------+----------------+----------------+----------------+
 |0 1 0 0 |0 1 0 1|      0x02      |             0x04cc              | ^
@@ -430,78 +683,98 @@ Original sample {{?UDP=RFC768}} over {{?IPv4=RFC791}} packet layout is illustrat
 |                      UDP payload (1200 bytes)                     | |
 |                                ...                                | v
 ~~~
-{: #original-udp-ipv4 title="Example UDP over IPv4 packet before optimization"}
+{: #original-udp-ipv4-ethernet title="Example UDP over IPv4 Ethernet frame before optimization"}
 
-Table below illustrates fields present in IPv4 header and UDP, their offsets in bits from the beginning of the packet and if they are likely to be static for most packets of a given traffic flow
+This example assumes that the peer supports templates, IPv4 total length, IPv4 header checksum, UDP length in IPv4 packet and UDP checksum in IPv4 packet derived field. These capabilities were communicated using the following `http-datagram-contexts` HTTP field in client requesting CONNECT-ETHERNET extended CONNECT.
+
+~~~
+http-datagram-contexts = templates=(max=1 segments=1), derived=(0 2 4 7), mtu=1500
+~~~
+{: #fig-http-datagram-contexts-example-2 title="http-datagram-contexts request example"}
+
+Total length and header checksum in IPv4 header as well as length and checksum in UDP header can be derived by the peer, so these fields are removed before calculating static segments. Resulting context for the derived field is defined using DERIVED_ASSIGN capsule:
+
+~~~
+DERIVED_ASSIGN Capsule {
+  Type (i) = 0x3ee31442,
+  Length (i) = 6,
+  Context ID (i) = 1,
+  Next Context ID (i) = 0,
+  Derived Field Type (i) = 0
+  Derived Field Type (i) = 2
+  Derived Field Type (i) = 4
+  Derived Field Type (i) = 7
+}
+~~~
+{: #ipv4-udp-ethernet-derived-assign title="DERIVED_ASSIGN Capsule for example IPv4/UDP ethernet frame"}
+
+Table below illustrates fields present in Ethernet, IPv4 and UDP headers after derived fields were removed, their offsets in bits from the beginning of the frame and if they are likely to be static for most packets of a given traffic flow
 
 | Offset | Field name | Length | Value | Static |
 | --- | --- | --- | --- | --- |
-| 0 | Version | 4 | 0100b | Yes |
-| 4 | Header length | 4 | 0101b | Yes |
-| 8 | Traffic Class | 8 | 0x02 | Yes |
-| 16 | Total length | 16 | 0x04cc | No |
-| 32 | Identification | 16 | 0x0000 | Yes |
-| 48 | Flags | 3 | 010b | Yes |
-| 51 | Fragment offset | 13 | 0000000000000b | Yes |
-| 64 | TTL | 8 | 0x40 | Yes |
-| 72 | Protocol | 8 | 0x11 | Yes |
-| 80 | Header checksum | 16 | 0xb21b | No |
-| 96 | Source address | 32 | 192.0.2.1 | Yes |
-| 128 | Destination address | 32 | 192.0.2.2 | Yes |
-| 160 | Source port | 16 | 0xc199 | Yes |
-| 176 | Destination port | 16 | 0x1151 | Yes |
-| 192 | Length | 16 | 0x04b8 | No |
-| 208 | Checksum | 16 | 0x72de | No |
-| 224 | UDP payload | 9600 | ... | No |
-{: #ipv4-udp-fields title="IPv4 header and UDP fields in example packet"}
+| 0 | Destination MAC address | 48 | 00:00:5E:00:53:01 | Yes |
+| 48 | Source MAC address | 48 | 00:00:5E:00:53:02 | Yes |
+| 96 | EtherType | 16 | 0x0800 | Yes |
+| 112 | Version | 4 | 0100b | Yes |
+| 116 | Header length | 4 | 0101b | Yes |
+| 120 | Traffic Class | 8 | 0x02 | Yes |
+| 128 | Identification | 16 | 0x0000 | Yes |
+| 144 | Flags | 3 | 010b | Yes |
+| 147 | Fragment offset | 13 | 0000000000000b | Yes |
+| 160 | TTL | 8 | 0x40 | Yes |
+| 168 | Protocol | 8 | 0x11 | Yes |
+| 176 | Source address | 32 | 192.0.2.1 | Yes |
+| 208 | Destination address | 32 | 192.0.2.2 | Yes |
+| 240 | Source port | 16 | 0xc199 | Yes |
+| 256 | Destination port | 16 | 0x1151 | Yes |
+| 272 | UDP payload | 9600 | ... | No |
+{: #ipv4-udp-ethernet-fields title="Ethernet, IPv4 and UDP header fields in example frame"}
 
-Static segments model the invariant parts:
+A single static segment model can be used for the initial part of the HTTP datagram after derived fields were removed:
 
 | Segment Offset | Segment Length | Segment Contents | Segment Payload |
 | --- | --- | --- | --- |
-| 0 | 2 | Version, Header length and Traffic Class | 0x4502 |
-| 4 | 6 | Identification, Flags, Fragment offset, TTL and Protocol | 0x000040004011 |
-| 12 | 12 | Source address, Destination address, Source port and Destination port | 0xc0000201c0000202c1991151 |
-{: #ipv4-udp-segments title="Static segments for example IPv4/UDP packet"}
+| 0 | 34 | Source MAC address, Destination MAC address, EtherType, Version, Header length and Traffic Class, Identification, Flags, Fragment offset, TTL, Protocol, Source address, Destination address, Source port and Destination port | 0x00005E00530100005E00530208004502000040004011c0000201c0000202c1991151 |
+{: #ipv4-udp-segment title="Static segment for example Ethernet/IPv4/UDP frame"}
 
-Resulting CONNECT_IP_OPTIMIZATION_CREATE capsule with proxy-allocated odd Context ID is illustrated below:
+Resulting TEMPLATE_ASSIGN capsule with proxy-allocated odd Context ID is illustrated below:
 
 ~~~
-CONNECT_IP_OPTIMIZATION_CREATE Capsule {
-  Type (i) = 0x1a768469,
-  Length (i) = 28,
+TEMPLATE_ASSIGN Capsule {
+  Type (i) = 0x3ee3143f,
+  Length (i) = 38,
   Context ID (i) = 3,
-  Static Segments Length (i) = 26,
+  Next Context ID (i) = 1,
   Static Segment {
     Segment Offset (i) = 0,
-    Segment Length (i) = 2,
-    Segment Payload = 0x4502,
-  },
-  Static Segment {
-    Segment Offset (i) = 4,
-    Segment Length (i) = 6,
-    Segment Payload = 0x000040004011,
-  },
-  Static Segment {
-    Segment Offset (i) = 12,
-    Segment Length (i) = 12,
-    Segment Payload = 0xc0000201c0000202c1991151,
+    Segment Length (i) = 34,
+    Segment Payload = 0x00005E00530100005E00530208004502000040004011c0000201c0000202c1991151,
   }
 }
 ~~~
-{: #ipv4-udp-optimization-create title="CONNECT_IP_OPTIMIZATION_CREATE Capsule for example IPv4/UDP packet"}
+{: #ipv4-udp-template-assign title="TEMPLATE_ASSIGN Capsule for example IPv4/UDP ethernet frame"}
 
-This template omits 20 bytes of repeated header material, increasing the effective MTU when datagrams are encapsulated in QUIC DATAGRAM frames.
+The resulting processing context chain reduces per-frame overhead by removing 34 bytes of repeated header material, increasing the effective MTU when datagrams are encapsulated in QUIC DATAGRAM frames.
 
-The sender concatenates all variable regions in increasing offset order. Because this template does not define checksum offload, the UDP checksum is computed by the sender as usual; the receiver does not perform checksum finishing for this context.
+The sender concatenates all variable regions in increasing offset order.
+
+Upon receiving the datagram with CID 3, client re-assembles the datagram by appending variable segments to the static, re-calculates derived fields and inserts them at appropriate locations in the datagram.
 
 # Security Considerations
 
-This specification changes how CONNECT-IP datagrams are constructed but does not weaken transport-layer integrity or confidentiality protections provided by the underlying HTTP mapping. All Capsules travel on the reliable control stream and inherit those protections.
+This specification changes how HTTP Datagrams are reconstructed but does not weaken transport-layer integrity or confidentiality protections provided by the underlying HTTP mapping. All Capsules travel on the reliable control stream and inherit those protections.
 
-Context state can be abused for resource exhaustion. Endpoints enforce negotiated limits from `connect-ip-optimizations`; they MUST reject creations that exceed the declared template budget and must release budget when a context is retired with CONNECT_IP_OPTIMIZATION_DELETE. Implementations SHOULD bound the number of static segments, validate lengths before allocation and cap per-context memory.
+## Resource Exhaustion
 
-Negotiation and Capsule handling are directional and immutable to reduce desynchronization risk. Even/odd Context ID allocation prevents collisions between endpoints; CID 0 is reserved and must not appear in Capsules. Unknown CIDs must be dropped. Reusing a CID within the same connection after deletion is not permitted; endpoints MUST allocate a fresh CID to change behavior.
+Processing contexts introduce receiver state and reconstruction work. An attacker could attempt to exhaust memory or CPU by creating excessive numbers of templates and static segments, purposely sending datagrams referencing not-yet-installed contexts and causing excessive buffering of unknown CIDs.
+
+Implementations MUST enforce limits on number of active templates and static segments and restrict memory used for buffering datagrams with unknown contexts.
+
+## Amplification
+
+Derived fields and template reconstruction increase the size of the reconstructed packet relative to the received datagram payload. An attacker could exploit this to amplify processing cost and perform a denial-of-service attack.
+
+Endpoints MUST ensure that reconstructed packet size does not exceed the negotiated MTU and SHOULD apply rate limiting when expansion ratios are abnormally high.
 
 # IANA Considerations
 
@@ -509,20 +782,88 @@ Negotiation and Capsule handling are directional and immutable to reduce desynch
 
 This specification registers the following values in the "HTTP Capsule Types" registry:
 
-| Value | Capsule Type
-+ --- + --- +
-| 0x1a768469 | CONNECT_IP_OPTIMIZATION_CREATE |
-| 0x1a76846a | CONNECT_IP_OPTIMIZATION_DELETE |
+Value | Capsule Type
+--- | ---
+0x3ee3143f | TEMPLATE_ASSIGN
+0x3ee31440 | TEMPLATE_ACK
+0x3ee31441 | TEMPLATE_CLOSE
+0x3ee31442 | DERIVED_ASSIGN
+0x3ee31443 | DERIVED_ACK
+0x3ee31444 | DERIVED_CLOSE
+0x3ee31445 | CHECKSUM_ASSIGN
+0x3ee31446 | CHECKSUM_ACK
+0x3ee31447 | CHECKSUM_CLOSE
+
+All of these new entries use the following values for these fields:
+
+Status:
+
+: provisional (permanent if this document is approved)
+
+Reference:
+
+: This document
+
+Change Controller:
+
+: IETF
+
+Contact:
+
+: MASQUE Working Group masque@ietf.org
+
+Notes:
+: None
 
 ## HTTP Field Name Registration
 
 This specification registers the following value in the "HTTP Field Name" registry:
 
-- Field Name: connect-ip-optimizations
+- Field Name: http-datagram-contexts
 - Status: provisional (permanent if approved)
 - Structured Type: Dictionary
 - Reference: This document
+- Comments: None
 
+## HTTP Datagram Derived Field Types Registry {#iana-derived-fields}
+
+IANA is requested to create a new registry titled "HTTP Datagram Derived Field Types". The registration policy is expert review as specified in {{Section 4.5 of ?IANA-POLICY=RFC8126}}. This new registry governs the Derived Field types that appear in DERIVED_ASSIGN capsule and `derived` list of `http-datagram-contexts` dictionary.
+
+This new registry contains five columns:
+
+Type:
+
+: A positive integer identifying the field type
+
+Name:
+
+: A short name of the field
+
+Description:
+
+: A description of the field
+
+Protocols:
+
+: A list of HTTP Upgrade Tokens that the derived field type can apply
+
+Reference:
+
+: An optional reference defining the use of the entry.
+
+The registry's initial entries are as follows:
+
+Type | Name | Description | Protocols | Reference
+--- | --- | --- | --- | ---
+0 | ipv4-total-length | IPv4 Total Length field derived from reconstructed packet size | connect-ip, connect-ethernet | This document
+1 | ipv6-payload-length | IPv6 Payload Length field derived from reconstructed packet size | connect-ip, connect-ethernet | This document
+2 | ipv4-udp-length | UDP Length derived from UDP header to end of IPv4 packet | connect-ip, connect-ethernet | This document
+3 | ipv6-udp-length | UDP Length derived from UDP header to end of IPv6 packet | connect-ip, connect-ethernet | This document
+4 | ipv4-header-checksum | IPv4 header checksum computed over IPv4 header | connect-ip, connect-ethernet | This document
+5 | ipv4-tcp-checksum | TCP checksum computed over IPv4 pseudo-header and segment | connect-ip, connect-ethernet | This document
+6 | ipv6-tcp-checksum | TCP checksum computed over IPv6 pseudo-header and segment | connect-ip, connect-ethernet | This document
+7 | ipv4-udp-checksum | UDP checksum computed over IPv4 pseudo-header and segment | connect-ip, connect-ethernet | This document
+8 | ipv6-udp-checksum | UDP checksum computed over IPv6 pseudo-header and segment | connect-ip, connect-ethernet | This document
 
 --- back
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -37,9 +37,9 @@ informative:
 
 This document defines extensions for HTTP Datagram-based protocols that improve transmission efficiency by introducing templates for compressing or deriving datagram fields.
 
-Reusable templates allow endpoints to associate Context Identifiers with static portions of packet headers, enabling datagrams to remove repeated byte sequences while remaining stateless on the wire. Derived field processing allows receivers to reconstruct certain header fields such as packet lengths and complete checksums based on the size of the reconstructed packet.
+These templates allow endpoints to define parts of datagrams that are static and can be removed, and other parts that can be derived (such as packet lengths and checksum values).
 
-Additionally, this document defines a checksum offload procedure enabling receivers to complete checksums using sender-provided partial values.
+Additionally, this document defines a checksum offload procedure enabling receivers to complete Internet checksums using sender-provided partial values.
 
 These optimisations reduce per-packet overhead, processing cost, and increase the effective maximum transmission unit (MTU) when datagrams are encapsulated in QUIC DATAGRAM frames.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -572,7 +572,7 @@ DERIVED_ASSIGN Capsule {
 ~~~
 {: #ipv6-tcp-derived-assign title="DERIVED_ASSIGN Capsule for example IPv6/TCP packet"}
 
-Table below illustrates fields present in IPv6 and TCP headers after derived field was removed, their offsets in bits from the beginning of the packet and whether they are likely to be static for most packets of a given traffic flow
+The table below illustrates fields present in IPv6 and TCP headers after derived field was removed, their offsets in bits from the beginning of the packet and whether they are likely to be static for most packets of a given traffic flow
 
 | Offset | Field name | Length | Value | Static |
 | --- | --- | --- | --- | --- |

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -47,7 +47,7 @@ These optimisations reduce per-packet overhead, processing cost, and increase th
 
 # Introduction
 
-The CONNECT-IP method {{!CONNECT-IP=RFC9484}} allows an HTTP client to establish an IP tunnel through an HTTP proxy and exchange IP packets using either HTTP/3 Datagrams specified in {{Section 2.1 of !HTTP-DATAGRAMS=RFC9297}} or DATAGRAM capsules specified in {{Section 3.5 of HTTP-DATAGRAMS}}. Similarly, CONNECT-ETHERNET {{!CONNECT-ETHERNET=I-D.ietf-masque-connect-ethernet}} allows carriage of Ethernet frames over HTTP Datagrams. In these protocols, each packet or frame is carried in full, including all transport and network headers, which provides simplicity and interoperability but incurs per-packet overhead due to the repeated transmission of largely invariant header fields.
+The CONNECT-IP method {{!CONNECT-IP=RFC9484}} allows an HTTP client to establish an IP tunnel through an HTTP proxy and exchange IP packets using either HTTP/3 Datagrams ({{Section 2.1 of !HTTP-DATAGRAMS=RFC9297}}) or DATAGRAM capsules ({{Section 3.5 of HTTP-DATAGRAMS}}). Similarly, CONNECT-ETHERNET {{!CONNECT-ETHERNET=I-D.ietf-masque-connect-ethernet}} allows sending Ethernet frames over HTTP Datagrams. These protocols send complete packets or frames by default, including all transport and network headers. This is a simple approach, but incurs per-packet overhead due to the repeated transmission of largely invariant header fields.
 
 Other HTTP Datagram-based protocols share similar properties: datagrams often contain structured packets where many header fields remain constant across a flow while only a subset of bytes change between packets. Transmitting complete packets therefore wastes bandwidth and processing resources.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -35,7 +35,7 @@ informative:
 
 --- abstract
 
-This document defines extensions for HTTP Datagram-based protocols that improve transmission efficiency by introducing reusable templates and derived field processing contexts.
+This document defines extensions for HTTP Datagram-based protocols that improve transmission efficiency by introducing templates for compressing or deriving datagram fields.
 
 Reusable templates allow endpoints to associate Context Identifiers with static portions of packet headers, enabling datagrams to remove repeated byte sequences while remaining stateless on the wire. Derived field processing allows receivers to reconstruct certain header fields such as packet lengths and complete checksums based on the size of the reconstructed packet.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -122,7 +122,7 @@ This document defines the following optional dictionary keys:
 
 : Indicates support for the checksum offload procedure defined in this document. A value of ?1 means the endpoint is willing to complete checksums using sender-provided partial values. If omitted or set to ?0, checksum offload is not supported.
 
-`mtu` (sf-integer):
+`mtu` (Integer):
 
 : Upper limit on maximum reconstructed packet size the receiver is willing to accept.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -118,7 +118,7 @@ This document defines the following optional dictionary keys:
 
 : A list of supported Derived Field Types as defined in {{iana-derived-fields}}.
 
-`checksum` (sf-boolean):
+`checksum` (Boolean):
 
 : Indicates support for the checksum offload procedure defined in this document. A value of ?1 means the endpoint is willing to complete checksums using sender-provided partial values. If omitted or set to ?0, checksum offload is not supported.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -1,6 +1,7 @@
 ---
 title: "Reusable templates, derived fields, and checksum offload for HTTP Datagrams"
-abbrev: "Reusable templates, derived fields, and checksum offload for HTTP Datagrams"
+title: "Extensions to Compress and Derive Fields in HTTP Datagrams"
+abbrev: "HTTP Datagram Compression"
 category: std
 
 docname: draft-rosomakho-masque-connect-ip-optimizations-latest

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -106,12 +106,13 @@ http-datagram-contexts = sf-dictionary
 
 This document defines the following optional dictionary keys:
 
-`templates` (sf-dictionary):
+`max-templates` (Integer):
 
-: Indicates support for reusable templates. The dictionary contains:
+: Maximum number of concurrently active template contexts the sender is willing to maintain for templates created by the peer. Absence of this key or value of 0 indicates that the sender does not support reusable templates.
 
-* `max` (sf-integer, mandatory): maximum number of concurrently active template contexts the sender is willing to maintain for templates created by the peer. A value of 0 indicates that the endpoint does not accept templates from the peer but may use templates for its own transmissions.
-* `segments` (sf-integer, optional): maximum number of static segments accepted within a single template.
+`max-templates-segments` (Integer):
+
+: Maximum number of static segments accepted within a single template. Absence of this key or value of 0 indicates that the sender does not impose a limit on number of static segments in a single template.
 
 `derived` (Inner List):
 
@@ -133,9 +134,9 @@ Capabilities are directional. Each endpoint advertises the processing contexts i
 
 ### Templates
 
-If the peer advertises the `templates` member with a `max` value greater than 0, the endpoint MAY create template contexts up to that limit using capsules defined in {{capsules}}.
+If the peer advertises the `max-templates`  value greater than 0, the endpoint MAY create template contexts up to that limit using capsules defined in {{capsules}}.
 
-An endpoint MUST NOT create templates exceeding the peer's advertised `segments` limit when that parameter is present.
+An endpoint MUST NOT create templates exceeding the peer's advertised `max-template-segments` limit when that parameter is present.
 
 If the peer advertises an `mtu` limit, the sender MUST NOT transmit a datagram that would reconstruct into a packet larger than the advertised limit after all processing contexts have been applied.
 
@@ -249,11 +250,11 @@ The receiver parses a TEMPLATE_ASSIGN capsule by reading, in order: the Context 
 
 Each Static Segment consists of a Segment Offset, a Segment Length, and exactly Segment Length octets of Segment Payload. Static segments MUST appear in strictly increasing Segment Offset order and MUST NOT overlap. There MUST be at least 1 byte between consecutive segments.
 
-A receiver that advertised a `segments` limit in `templates` dictionary of `http-datagram-contexts` MUST ensure that the template does not contain more static segments. A receiver that advertised a `mtu` limit in `http-datagram-contexts` MUST ensure that the sum of Segment Offset and Segment Length of the final segment does not exceed the MTU limit. Final reconstructed packet size validation is performed during packet reconstruction ({{reconstruction}}). The capsule MUST end immediately after the last static segment.
+A receiver that advertised a `max-templates-segments` limit MUST ensure that the template does not contain more static segments. A receiver that advertised a `mtu` limit in `http-datagram-contexts` MUST ensure that the sum of Segment Offset and Segment Length of the final segment does not exceed the MTU limit. Final reconstructed packet size validation is performed during packet reconstruction ({{reconstruction}}). The capsule MUST end immediately after the last static segment.
 
 If any of the capsule fields are malformed upon reception, the receiver of the capsule MUST follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
-A receiver that has already accepted the maximum number of templates it advertised via the `max` member of `templates` in `http-datagram-contexts` MUST treat any additional TEMPLATE_ASSIGN capsule an error and MUST follow the same error-handling procedure.
+A receiver that has already accepted the maximum number of templates it advertised via the `max-templates` member in `http-datagram-contexts` MUST treat any additional TEMPLATE_ASSIGN capsule an error and MUST follow the same error-handling procedure.
 
 Per-packet validation uses the reconstruction procedure described in {{reconstruction}}.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -1,5 +1,4 @@
 ---
-title: "Reusable templates, derived fields, and checksum offload for HTTP Datagrams"
 title: "Extensions to Compress and Derive Fields in HTTP Datagrams"
 abbrev: "HTTP Datagram Compression"
 category: std

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -114,7 +114,7 @@ This document defines the following optional dictionary keys:
 * `max` (sf-integer, mandatory): maximum number of concurrently active template contexts the sender is willing to maintain for templates created by the peer. A value of 0 indicates that the endpoint does not accept templates from the peer but may use templates for its own transmissions.
 * `segments` (sf-integer, optional): maximum number of static segments accepted within a single template.
 
-`derived` (sf-list):
+`derived` (Inner List):
 
 : A list of supported Derived Field Types as defined in {{iana-derived-fields}}.
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -237,11 +237,11 @@ Segment Offset:
 
 Segment Length:
 
-: Number of bytes in this static segment, encoded as a variable-length integer
+: Length of the Segement Payload field, encoded as a variable-length integer
 
 Segment Payload:
 
-: the static bytes to insert at the Segment Offset
+: Static bytes to insert at the Segment Offset
 
 #### Parsing and validation
 

--- a/draft-rosomakho-masque-connect-ip-optimizations.md
+++ b/draft-rosomakho-masque-connect-ip-optimizations.md
@@ -62,7 +62,7 @@ In addition, this document defines a checksum offload procedure enabling endpoin
 
 When HTTP Datagrams are encapsulated in QUIC DATAGRAM frames, these optimisations also increase the effective maximum transmission unit (MTU) by reducing the number of bytes carried inside each QUIC packet.
 
-All extensions are negotiated during the HTTP request/response handshake and signalled using Capsules on the reliable control stream. Endpoints can always fall back to transmitting complete datagrams using Context ID 0, which represents unoptimised datagrams containing the full payload as defined by the underlying HTTP Datagram protocol.
+All extensions are negotiated during the HTTP request/response handshake and signalled using Capsules on the reliable control stream. Endpoints can always fall back to transmitting complete datagrams using Context Identifier 0, which represents unoptimised datagrams containing the full payload as defined by the underlying HTTP Datagram protocol.
 
 # Conventions and Definitions
 
@@ -70,9 +70,9 @@ All extensions are negotiated during the HTTP request/response handshake and sig
 
 The following terms are used in this document:
 
-Context Identifier (CID):
+Context Identifier (Context ID):
 
-: A numeric identifier associated with a Processing Context. CID encoding and allocation follow the rules defined in {{Section 4 of !CONNECT-UDP=RFC9298}}. CID 0 indicates that the datagram payload is delivered without additional processing as defined by the underlying HTTP Datagram protocol.
+: A numeric identifier associated with a Processing Context. Context ID encoding and allocation follow the rules defined in {{Section 4 of !CONNECT-UDP=RFC9298}}. Context ID 0 indicates that the datagram payload is delivered without additional processing as defined by the underlying HTTP Datagram protocol.
 
 Processing Context:
 
@@ -182,9 +182,9 @@ This specification defines multiple capsule types to construct, acknowledge, and
 
 ### Processing Context Construction {#assign}
 
-Processing contexts are created using capsules that define a new unique non-zero `Context ID` encoded as a variable-length integer. A CID MUST NOT be reused. As specified in {{Section 4 of CONNECT-UDP}}, even-numbered CIDs are allocated by the client and odd-numbered by the proxy.
+Processing contexts are created using capsules that define a new unique non-zero `Context ID` encoded as a variable-length integer. A Context ID MUST NOT be reused. As specified in {{Section 4 of CONNECT-UDP}}, even-numbered Context IDs are allocated by the client and odd-numbered by the proxy.
 
-Each processing context MAY reference an already-defined parent context using `Next Context ID` encoded as a variable-length integer. A context MUST reference only a CID previously defined by the peer. Forward references are not permitted. Processing context without a parent is identified by `Next Context ID` set to 0. A processing chain MUST NOT contain more than one context of the same type. A receiver that detects such a condition MUST treat the context as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
+Each processing context MAY reference an already-defined parent context using `Next Context ID` encoded as a variable-length integer. A context MUST reference only a Context ID previously defined by the peer. Forward references are not permitted. Processing context without a parent is identified by `Next Context ID` set to 0. A processing chain MUST NOT contain more than one context of the same type. A receiver that detects such a condition MUST treat the context as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
 A receiver of an *_ASSIGN capsule with an invalid `Context ID` or unknown `Next Context ID` MUST treat it as malformed and follow the error-handling procedure defined in {{Section 3.3 of HTTP-DATAGRAMS}}.
 
@@ -403,9 +403,9 @@ Processing of the CHECKSUM_CLOSE capsule is described in {{close}}
 
 This section defines how endpoints construct and consume HTTP Datagram payloads using Processing Contexts.
 
-A datagram carries a Context Identifier that selects the initial Processing Context. A context MAY reference a parent context using Next Context ID. The complete behavior is defined by recursively following parent contexts until reaching CID 0.
+A datagram carries a Context Identifier that selects the initial Processing Context. A context MAY reference a parent context using Next Context ID. The complete behavior is defined by recursively following parent contexts until reaching Context ID 0.
 
-CID 0 indicates that no processing is applied and the payload is delivered unchanged to the underlying HTTP Datagram protocol.
+Context ID 0 indicates that no processing is applied and the payload is delivered unchanged to the underlying HTTP Datagram protocol.
 
 ## Sender behavior
 
@@ -433,11 +433,11 @@ If the context chain contains a checksum offload context, the sender MUST place 
 
 ### Context Selection
 
-If a packet does not match any available context, the sender MUST use CID 0 and transmit the complete packet.
+If a packet does not match any available context, the sender MUST use Context ID 0 and transmit the complete packet.
 
 ## Receiver behavior {#reconstruction}
 
-Upon receiving an HTTP Datagram with a non-zero Context ID, the receiver retrieves the referenced Processing Context and recursively resolves its parent contexts until CID 0 is reached.
+Upon receiving an HTTP Datagram with a non-zero Context ID, the receiver retrieves the referenced Processing Context and recursively resolves its parent contexts until Context ID 0 is reached.
 
 If any referenced context is unknown, the receiver MAY buffer the datagram as described in {{ack}} or drop it.
 
@@ -636,7 +636,7 @@ The resulting processing context chain reduces per-packet overhead by removing 5
 
 The sender concatenates all variable regions in increasing offset order. Packets that do not match this template (for example packets with IPv6 extension headers or without TCP options) are sent using Context ID 0 or associated with a new context.
 
-Upon receiving the datagram with CID 6, proxy re-assembles the datagram by concatenating static and variable segments according to the offsets, re-calculates Payload Length and inserts it into IPv6 header and completes the TCP checksum using the sender-provided pseudo-header partial checksum.
+Upon receiving the datagram with Context ID 6, proxy re-assembles the datagram by concatenating static and variable segments according to the offsets, re-calculates Payload Length and inserts it into IPv6 header and completes the TCP checksum using the sender-provided pseudo-header partial checksum.
 
 ## CONNECT-ETHERNET: UDP over IPv4 with template and derived fields
 
@@ -759,7 +759,7 @@ The resulting processing context chain reduces per-frame overhead by removing 34
 
 The sender concatenates all variable regions in increasing offset order.
 
-Upon receiving the datagram with CID 3, client re-assembles the datagram by appending variable segments to the static, re-calculates derived fields and inserts them at appropriate locations in the datagram.
+Upon receiving the datagram with Context ID 3, client re-assembles the datagram by appending variable segments to the static, re-calculates derived fields and inserts them at appropriate locations in the datagram.
 
 # Security Considerations
 
@@ -767,7 +767,7 @@ This specification changes how HTTP Datagrams are reconstructed but does not wea
 
 ## Resource Exhaustion
 
-Processing contexts introduce receiver state and reconstruction work. An attacker could attempt to exhaust memory or CPU by creating excessive numbers of templates and static segments, purposely sending datagrams referencing not-yet-installed contexts and causing excessive buffering of unknown CIDs.
+Processing contexts introduce receiver state and reconstruction work. An attacker could attempt to exhaust memory or CPU by creating excessive numbers of templates and static segments, purposely sending datagrams referencing not-yet-installed contexts and causing excessive buffering of unknown Context IDs.
 
 Implementations MUST enforce limits on number of active templates and static segments and restrict memory used for buffering datagrams with unknown contexts.
 


### PR DESCRIPTION
* Separated templates and checksum offload
* Added derived fields for lengths and complete checksums. Added IANA registry for derived fields (more stuff might be added in the future for other protocols)
* Changed capsule design to include Next Context ID
* Aligned ASSIGN/ACK/CLOSE capsule design and naming with other masque drafts
* Templates are applicable to any HTTP datagram based protocols
* CONNECT-ETHERNET can use same derived fields and checksum offload as CONNECT-IP
* Added `mtu` and `segments` restrictions based on feedback from the working group

Keeping the draft name as it is for now - will update it if working group decides to adopt this at some point in the future.

It seems that with all these optimisations sending Ethernet over HTTP/QUIC Datagrams might become viable - at least from MTU perspective!